### PR TITLE
Fix Toolbox crash

### DIFF
--- a/source/tools/toolbox/ToolboxPlaceholder.hx
+++ b/source/tools/toolbox/ToolboxPlaceholder.hx
@@ -60,10 +60,7 @@ class ToolboxPlaceholder extends states.MusicBeatState {
 			ui_Skin = Options.getData("uiSkin");
 
 		if (PlayState.instance == null) {
-			pages["Tools"][1] = null;
-			#if debug
-			pages["Tools"][2] = null;
-			#end
+			pages["Tools"][0] = null;
 		}
 
 		MusicBeatState.windowNameSuffix = "";


### PR DESCRIPTION
This was a leftover from the options menu code and was never fixed, letting you crash the game by selecting the charter when it's not supposed to be there.